### PR TITLE
Fixed compilation errors and warnings + benchmark config

### DIFF
--- a/Config/ntuple_cfg.h
+++ b/Config/ntuple_cfg.h
@@ -8,7 +8,7 @@
 struct ntuple_cfg {
     std::string sampleName, sampleTitle;
     std::string triggerName, triggerTitle;
-    std::string puFilename;     
+    std::string puFilename;
     std::string run;
     std::string outDirBase;
     bool doFit;
@@ -23,12 +23,14 @@ ntuple_cfg singleMuRun276243();
 ntuple_cfg singleMuRun281693();
 ntuple_cfg zeroBiasRun276653();
 ntuple_cfg VBF_HInv();
+ntuple_cfg benchmark_cfg();
 
 // The Ntuple cfg to use:
 ntuple_cfg GetNtuple_cfg()
 {
     return singleMuRun276243();
 }
+
 
 // Single Muon run 276243
 ntuple_cfg singleMuRun276243()
@@ -127,6 +129,29 @@ ntuple_cfg VBF_HInv()
     config.baseOWdir    = "/afs/cern.ch/work/s/sbreeze/L1TriggerStudiesOutput"
         "/20161102_MC_HInv_highMET/";
     return config;
+}
+
+
+ntuple_cfg benchmark_cfg()
+{
+  ntuple_cfg config;
+  config.sampleName   = "Data";
+  config.sampleTitle  = "2016 Data";
+  config.triggerName  = "SingleMu";
+  config.triggerTitle = "Single Muon";
+  config.puFilename   = "";
+  config.run          = "276243";
+  config.outDirBase   = "/vagrant/benchmark/legacy";
+  config.doFit        = false;
+  config.puType       = {"0PU12","13PU19","20PU"};
+  config.puBins       = {0,13,20,999};
+  config.inFiles      = {"file:///vagrant/data/*.root"};
+  config.baseOWdir    = config.outDirBase +
+      "/20161101_"+config.sampleName+"_run-"+config.run+"_"+\
+      config.triggerName+"_hadd/";
+  config.outDir       = config.outDirBase+"/"+TL1DateTime::GetDate()+"_"+\
+  config.sampleName+"_run-"+config.run+"_"+config.triggerName;
+  return config;
 }
 
 #endif

--- a/Event/TL1EventClass.h
+++ b/Event/TL1EventClass.h
@@ -37,7 +37,7 @@ class TL1EventClass
         // Filter flags
         bool fMuonFilterPassFlag, fMetFilterPassFlag;
         std::vector<bool> fJetFilterPassFlags;
-        
+
         // Recalc L1 MET sums
         double fRecalcL1Met, fRecalcL1MetPhi;
         double fRecalcL1MetHF, fRecalcL1MetPhiHF;
@@ -134,7 +134,7 @@ void TL1EventClass::GetDerivatives()
     if( fPrimitiveEvent->fIsEmuCaloTower ) this->GetRecalcL1EmuMet();
     //this->GetRecalcL1Mht();
     //this->GetRecalcL1Ett();
-    
+
     //this->GetRecalcRecoHtSums();
     //this->GetRecalcRecoEtt();
 
@@ -445,7 +445,7 @@ void TL1EventClass::GetRecalcRecoEtt()
 {
     double jetEt(0.0);
     int jetCount = 0;
-    for(int iJet=0; iJet<fPrimitiveEvent->fJets->nJets; ++iJet)
+    for(auto iJet=0; iJet<fPrimitiveEvent->fJets->nJets; ++iJet)
     {
         if( fPrimitiveEvent->fJets->etCorr[iJet] >= 30.0 )
         {
@@ -462,7 +462,7 @@ void TL1EventClass::GetLeadingRecoJet()
     int iLeadingReco = 0;
     double leadingRecoEt = 10.0;
     fIsLeadingRecoJet = false;
-    for(int iReco=0; iReco<fJetFilterPassFlags.size(); ++iReco)
+    for(unsigned int iReco=0; iReco<fJetFilterPassFlags.size(); ++iReco)
     {
         // If central jet, require tightLepVeto and muMult==0
         auto recoJet = fPrimitiveEvent->fJets;
@@ -494,7 +494,7 @@ void TL1EventClass::GetMatchedL1Jet(const std::string & l1Type)
 
     // Get Leading jet parameters
     auto recoJet = fPrimitiveEvent->fJets;
-    double leadingRecoJetEta = recoJet->eta[fLeadingRecoJetIndex]; 
+    double leadingRecoJetEta = recoJet->eta[fLeadingRecoJetIndex];
     double leadingRecoJetPhi = recoJet->phi[fLeadingRecoJetIndex];
 
     std::vector<double> l1JetEts, l1JetEtas, l1JetPhis;
@@ -510,7 +510,7 @@ void TL1EventClass::GetMatchedL1Jet(const std::string & l1Type)
         l1JetEtas = fL1EmuJetEta;
         l1JetPhis = fL1EmuJetPhi;
     }
-    for(int iL1=0; iL1<l1JetEts.size(); ++iL1)
+    for(unsigned int iL1=0; iL1<l1JetEts.size(); ++iL1)
     {
         // Get l1 jet parameters
         double l1JetEta = l1JetEtas[iL1];
@@ -519,7 +519,7 @@ void TL1EventClass::GetMatchedL1Jet(const std::string & l1Type)
         // Check dEta > dR
         double dEta = leadingRecoJetEta - l1JetEta;
         if( dEta > minDeltaR ) continue;
-        
+
         // Check dPhi > dR
         double dPhi = leadingRecoJetPhi - l1JetPhi;
         if( dPhi > minDeltaR ) continue;

--- a/MakePlots/makeJetResolutions.cxx
+++ b/MakePlots/makeJetResolutions.cxx
@@ -1,5 +1,6 @@
 #include <string>
 #include <vector>
+#include <iostream>
 
 #include "../Plotting/tdrstyle.C"
 #include "../Event/TL1EventClass.h"
@@ -10,6 +11,7 @@
 #include "../Config/jetResolutions_cfg.h"
 
 #include "../Debug/DebugHandler.h"
+
 
 double FoldPhi(double phi);
 
@@ -57,9 +59,9 @@ void makeJetResolutions(const int & CHUNK, const int & NJOBS, const int & NENT, 
         end   = (CHUNK+1) * NEvents;
         if( CHUNK == NJOBS-1 ) end = NENT;
     }
-    
+
     // Loop
-    for(int i=start; i<end && !COMBINE; ++i)
+    for(auto i=start; i<end && !COMBINE; ++i)
     {
         event->GetEntry(i);
         TL1Progress::PrintProgressBar(i-start, end-start);

--- a/Plotting/TL1Resolution.h
+++ b/Plotting/TL1Resolution.h
@@ -10,6 +10,8 @@
 #include <TCanvas.h>
 #include <TLegend.h>
 #include <TLatex.h>
+#include "THStack.h"
+#include "TLine.h"
 
 #include "TL1Plots.h"
 #include "../Debug/DebugHandler.h"
@@ -61,7 +63,7 @@ void TL1Resolution::InitPlots()
     fPlot.back()->Sumw2();
     fPlot.back()->GetXaxis()->SetTitle(GetXAxisTitle().c_str());
     fPlot.back()->GetYaxis()->SetTitle("a.u.");
-    for(int ipu=0; ipu<this->GetPuType().size(); ++ipu)
+    for(unsigned int ipu=0; ipu<this->GetPuType().size(); ++ipu)
     {
         fPlot.emplace_back(new TH1F(Form("res_%s_%s_%s_%s",fPlotType.c_str(),fXName.c_str(),fYName.c_str(),this->GetPuType()[ipu].c_str()),"", fBins.size()-1,&(fBins)[0]));
         fPlot.back()->SetDirectory(0);
@@ -87,7 +89,7 @@ void TL1Resolution::OverwritePlots()
     double norm(fPlot.back()->Integral());
     if( norm > 0.0 ) fPlot.back()->Scale(1./norm);
 
-    for(int ipu=0; ipu<this->GetPuType().size(); ++ipu)
+    for(unsigned int ipu=0; ipu<this->GetPuType().size(); ++ipu)
     {
         fPlot.push_back((TH1F*)rootFile->Get(Form("%s_%s",this->GetOverwriteHistname().c_str(),this->GetPuType()[ipu].c_str())));
         fPlot.back()->SetDirectory(0);
@@ -99,11 +101,11 @@ void TL1Resolution::OverwritePlots()
     delete rootFile;
 }
 
-void TL1Resolution::Fill(const double & xVal, const double & yVal, const int & pu=0)
+void TL1Resolution::Fill(const double & xVal, const double & yVal, const int & pu)
 {
     double div(GetFillVal(xVal, yVal));
     fPlot[0]->Fill(div,this->GetPuWeight(pu));
-    for(int ipu=0; ipu<this->GetPuType().size(); ++ipu)
+    for(unsigned int ipu=0; ipu<this->GetPuType().size(); ++ipu)
     {
         if( pu >= this->GetPuBins()[ipu] && pu < this->GetPuBins()[ipu+1] )
             fPlot[ipu+1]->Fill(div,this->GetPuWeight(pu));
@@ -112,7 +114,7 @@ void TL1Resolution::Fill(const double & xVal, const double & yVal, const int & p
 
 void TL1Resolution::DrawPlots()
 {
-    TCanvas * can(new TCanvas(Form("can_%f",this->GetRnd()),"")); 
+    TCanvas * can(new TCanvas(Form("can_%f",this->GetRnd()),""));
 
     fPlot[0]->SetLineColor(kBlue-4);
     fPlot[0]->SetMarkerColor(kBlue-4);
@@ -141,9 +143,9 @@ void TL1Resolution::DrawPlots()
 
     THStack * stack(new THStack("hs",""));
     double norm(0.0);
-    for(int ipu=0; ipu<this->GetPuType().size(); ++ipu)
+    for(unsigned int ipu=0; ipu<this->GetPuType().size(); ++ipu)
     {
-        this->SetColor(fPlot[ipu+1], ipu, this->GetPuType().size()); 
+        this->SetColor(fPlot[ipu+1], ipu, this->GetPuType().size());
         fPlot[ipu+1]->SetMinimum(0.0);
         fRootFile->WriteTObject(fPlot[ipu+1]);
 
@@ -162,7 +164,7 @@ void TL1Resolution::DrawPlots()
         //fRootFile->WriteTObject(fitFcn2);
     }
 
-    TCanvas * can2(new TCanvas(Form("can_%f",this->GetRnd()),"")); 
+    TCanvas * can2(new TCanvas(Form("can_%f",this->GetRnd()),""));
     TLegend * leg(new TLegend(0.65,0.55,0.88,0.55+0.05*this->GetPuType().size()));
     leg->AddEntry(stack);
 


### PR DESCRIPTION
- fixed compilation errors (missing headers) and warnings (comparison between unsigned and signed integers) for `MakePlots/makeJetResolutions.cxx`
 - added `ntuple_cfg::benchmark_cfg` for local testing